### PR TITLE
fix nulerror

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -563,7 +563,9 @@ impl FastText {
     }
 
     pub fn predict(&self, text: &str, k: i32, threshold: f32) -> Result<Vec<Prediction>, String> {
-        let c_text = CString::new(text).map_err(|e| format!("{:?}", e))?;
+        let string_binding = text.replace("\0","");
+        let clean_str = string_binding.as_str();
+        let c_text = CString::new(clean_str).map_err(|e| format!("{:?}", e))?;
         unsafe {
             let ret = ffi_try!(cft_fasttext_predict(
                 self.inner,

--- a/tests/test_fasttest.rs
+++ b/tests/test_fasttest.rs
@@ -42,7 +42,7 @@ fn test_fasttext_predict() {
         .load_model("tests/fixtures/cooking.model.bin")
         .unwrap();
     let preds = fasttext
-        .predict("Which baking dish is best to bake a banana bread ?", 2, 0.0)
+        .predict("Which baking\0 dish is best to bake a banana bread ?", 2, 0.0)
         .unwrap();
     assert_eq!(2, preds.len());
     assert_eq!("__label__baking", &preds[0].label);


### PR DESCRIPTION
fix nulerror by replace '\0'
maybe we should consider function signatures 
all tests pass on my mac